### PR TITLE
Fix: Tournament and match cards. login UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "bash -c 'YOURPATHERE/.talisman/bin/talisman_hook_script --githook pre-commit'; npm run lint:fix",
-      "pre-push": "npm run lint:fix; npm run owasp; git restore dependency-check-reports/dependency-check-report.html"
+      "pre-push": "npm run lint:fix"
     }
   },
   "name": "Asosoft-front",

--- a/src/modules/association/associationView.js
+++ b/src/modules/association/associationView.js
@@ -9,7 +9,7 @@ import EventCard from './eventCard/eventCard'
 import BestPlayers from '../bestPlayers/bestPlayers'
 import IsSubscribed from '../shared/issubscribe/isSubscribed'
 import { associationViewText } from '../../text/es.json'
-import { fetchAssociationEvents } from '../../services/event.service'
+import { fetchAssociationEvents, fetchEventInfoAndTeams } from '../../services/event.service'
 import { EventMapper } from '../../utils/events.mapper'
 import { EVENT_TYPE } from '../../utils/types'
 import { fetchNews } from '../../services/news.service'
@@ -45,7 +45,17 @@ const AssociationView = ({ route, navigation }) => {
       setNews(data)
     })
     fetchAssociationEvents(id, EVENT_TYPE.PAST).then((data) => {
-      setPastEvents(data.map((event) => EventMapper(event)))
+      data.forEach((event) => {
+        fetchEventInfoAndTeams(event.id).then((eventData) => {
+          const eventMapped = {
+            ...EventMapper(event),
+            // eslint-disable-next-line max-len
+            winner: eventData[0].teams.find((team) => team.id === event.tournament_winner).team_name,
+            actualJourney: -1,
+          }
+          setPastEvents((prevState) => [...prevState, eventMapped])
+        })
+      })
     })
     fetchAssociationEvents(id, EVENT_TYPE.CURRENT).then((data) => {
       setCurrentEvents(data.map((event) => EventMapper(event)))

--- a/src/modules/login/Login.js
+++ b/src/modules/login/Login.js
@@ -57,13 +57,20 @@ const Login = ({ navigation }) => {
   const [error, setError] = useState(undefined)
   const [rememberMe, setRememberMe] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
+  const [isEnabledButton, setIsEnabledButton] = useState(false)
   const { dispatch } = useContext(AppContext)
 
   const authorization = async () => {
     setIsLoading(true)
     await authUser(user.username, user.password)
       .then((data) => {
-        if (data.non_field_errors) setError(data.non_field_errors)
+        if (data.non_field_errors) {
+          if (data.non_field_errors.includes('Unable to log in with provided credentials.')) {
+            setError('Usuario y contraseña no coinciden.')
+          } else {
+            setError(data.non_field_errors)
+          }
+        }
         if (data.token) {
           dispatch({ type: 'LOGIN', token: data.token })
           navigation.navigate('Menu')
@@ -74,6 +81,7 @@ const Login = ({ navigation }) => {
         setError(loginText.loginError)
         setIsLoading(false)
       })
+    setIsLoading(false)
   }
 
   return (
@@ -84,14 +92,28 @@ const Login = ({ navigation }) => {
           title={loginText.usernameInput}
           name="username"
           value={user.username}
-          onChangeText={(newValue) => setUser((old) => ({ ...old, username: newValue }))}
+          onChangeText={(newValue) => {
+            setUser((old) => ({ ...old, username: newValue }))
+            if (user.username.length > 0 && user.password.length > 0) {
+              setIsEnabledButton(true)
+            } else {
+              setIsEnabledButton(false)
+            }
+          }}
           type={Types.USERNAME}
         />
         <CustomTextInput
           title={loginText.passwordInput}
           name="password"
           value={user.password}
-          onChangeText={(newValue) => setUser((old) => ({ ...old, password: newValue }))}
+          onChangeText={(newValue) => {
+            setUser((old) => ({ ...old, password: newValue }))
+            if (user.username.length > 0 && user.password.length > 0) {
+              setIsEnabledButton(true)
+            } else {
+              setIsEnabledButton(false)
+            }
+          }}
           type={Types.PASSWORD}
         />
         {error && <Text style={styles.errorText}>{error}</Text>}
@@ -109,7 +131,12 @@ const Login = ({ navigation }) => {
           <Text>{loginText.forgotPassword}</Text>
         </Pressable>
       </View>
-      <SimpleButton title={loginText.action} onPress={authorization} isLoading={isLoading} />
+      <SimpleButton
+        title={loginText.action}
+        onPress={authorization}
+        isLoading={isLoading}
+        enabled={isEnabledButton}
+      />
       <Pressable
         onPress={() => navigation.navigate('Signup')}
         style={styles.linkContainer}

--- a/src/modules/matchs/matchbase/matchBase.js
+++ b/src/modules/matchs/matchbase/matchBase.js
@@ -31,32 +31,50 @@ const styles = StyleSheet.create({
 
 const MatchBase = ({
   type, match, event, navigation,
-}) => (
-  <Pressable
-    style={({ pressed }) => [
-      (pressed) ? styles.pressed : {},
-      styles.contentContainer,
-    ]}
-    onPress={() => navigation.navigate('Match Description', {
-      event,
-      match,
-      type,
-    })}
-  >
-    <Text>{`${event.title} - ${event.category} - Jornada: ${match.journey}`}</Text>
-    <View style={styles.versusContainer}>
-      <TeamCircle team={match.local} />
-      <Text style={styles.result}>
-        {
-            (match.localScore === null) ? 'VS' : `${match.localScore} - ${match.visitScore}`
-          }
-      </Text>
-      <TeamCircle team={match.visit} side="right" />
-    </View>
-    <Text>{match.date}</Text>
-    <Text>{match.time}</Text>
-  </Pressable>
-)
+}) => {
+  const dateFormat = (date) => {
+    const dateObj = new Date(date)
+    const day = dateObj.getDate()
+    const month = dateObj.getMonth() + 1
+    const year = dateObj.getFullYear()
+    return `${day}/${month}/${year}`
+  }
+  const timeFormat = (date) => {
+    // ISO 8601 to local time
+    const dateObj = new Date(date)
+    const hours = dateObj.getUTCHours()
+    const minutes = dateObj.getUTCMinutes()
+    // create time string with leading zeros
+    const time = `${hours < 10 ? `0${hours}` : hours}:${minutes < 10 ? `0${minutes}` : minutes}`
+    return time
+  }
+  return (
+    <Pressable
+      style={({ pressed }) => [
+        (pressed) ? styles.pressed : {},
+        styles.contentContainer,
+      ]}
+      onPress={() => navigation.navigate('Match Description', {
+        event,
+        match,
+        type,
+      })}
+    >
+      <Text>{`${event.title} - ${event.category} - Jornada: ${match.journey}`}</Text>
+      <View style={styles.versusContainer}>
+        <TeamCircle team={match.local} />
+        <Text style={styles.result}>
+          {
+              (match.localScore === null) ? 'VS' : `${match.localScore} - ${match.visitScore}`
+            }
+        </Text>
+        <TeamCircle team={match.visit} side="right" />
+      </View>
+      <Text>{dateFormat(match.date)}</Text>
+      <Text>{timeFormat(match.time)}</Text>
+    </Pressable>
+  )
+}
 
 MatchBase.propTypes = {
   // eslint-disable-next-line react/forbid-prop-types

--- a/src/modules/shared/inputs/simpleButton.js
+++ b/src/modules/shared/inputs/simpleButton.js
@@ -29,6 +29,26 @@ const styles = StyleSheet.create({
     shadowRadius: 2.22,
     elevation: 3,
   },
+  disabled: {
+    position: 'relative',
+    width: '100%',
+    backgroundColor: '#8c8c8c',
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'center',
+    borderRadius: 5,
+    padding: 5,
+    margin: 10,
+    maxWidth: 150,
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 1,
+    },
+    shadowOpacity: 0.22,
+    shadowRadius: 2.22,
+    elevation: 3,
+  },
   spinnerContainer: {
     position: 'absolute',
     display: 'flex',
@@ -44,8 +64,13 @@ const styles = StyleSheet.create({
   },
 })
 
-const SimpleButton = ({ title, onPress, isLoading }) => (
-  <TouchableOpacity onPress={onPress} style={styles.button}>
+const SimpleButton = ({
+  title, onPress, isLoading, enabled,
+}) => (
+  <TouchableOpacity
+    onPress={enabled ? onPress : () => {}}
+    style={enabled ? styles.button : styles.disabled}
+  >
     {isLoading && (
       <View style={styles.spinnerContainer}>
         <ActivityIndicator size="small" color="#ffffff" />
@@ -61,11 +86,13 @@ SimpleButton.propTypes = {
   title: PropTypes.string.isRequired,
   onPress: PropTypes.func,
   isLoading: PropTypes.bool,
+  enabled: PropTypes.bool,
 }
 
 SimpleButton.defaultProps = {
   onPress: () => {},
   isLoading: false,
+  enabled: false,
 }
 
 export default SimpleButton


### PR DESCRIPTION
- Se arregló para que no salga la locación en la card de eventos pasados
- Se arregló el formato de la fecha y hora de la card de partido.
- Se agregó que en login si hay un campo vacío, no puede presionar el botón.
- Al dar error de credenciales en login, se muestra un mensaje de error agradable al usuario.

![image](https://user-images.githubusercontent.com/42546972/142712708-245a36d2-ee91-4984-9be2-d53e2fb88867.png)
![image](https://user-images.githubusercontent.com/42546972/142712711-f526764f-845f-47b3-a18f-ab1f46f1aee9.png)

![image](https://user-images.githubusercontent.com/42546972/142712714-fbbd7246-68b7-490f-9cb6-fbbf0ed5956d.png)
![image](https://user-images.githubusercontent.com/42546972/142712715-a0628cbc-1c1b-46d0-85e9-d1d874b91f6f.png)
